### PR TITLE
update #include headers to compile on gcc12

### DIFF
--- a/hexer/BaseGrid.cpp
+++ b/hexer/BaseGrid.cpp
@@ -5,6 +5,7 @@
 #include "Path.hpp"
 #include "exception.hpp"
 #include <iostream>
+#include <cmath>
 
 namespace hexer
 {

--- a/hexer/HexGrid.cpp
+++ b/hexer/HexGrid.cpp
@@ -1,5 +1,6 @@
 #include <hexer/BaseGrid.hpp>
 #include <hexer/HexGrid.hpp>
+#include <cmath>
 
 namespace hexer
 {

--- a/hexer/Path.hpp
+++ b/hexer/Path.hpp
@@ -36,6 +36,7 @@
 #include <vector>
 #include <ostream>
 #include <iostream>
+#include <algorithm>
 
 #include "Mathpair.hpp"
 #include "Segment.hpp"


### PR DESCRIPTION
I noticed that Hexer failed to compile on my system (Ubuntu 22.04, gcc12). It's compiling after these fixes.